### PR TITLE
[WiP] WAC processors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -92,6 +92,22 @@
       "integrity": "sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==",
       "dev": true
     },
+    "@types/jsonwebtoken": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.3.2.tgz",
+      "integrity": "sha512-Mkjljd9DTpkPlrmGfTJvcP4aBU7yO2QmW7wNVhV4/6AEUxYoacqU7FJU/N0yFEHTsIrE4da3rUrjrR5ejicFmA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/jws": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@types/jws/-/jws-3.2.0.tgz",
+      "integrity": "sha512-2s6isKtNTfbfeP/VtvdB9JXE1LkFXndO2AjQ2f+nvTqwL8bxK1s9qxmymwklCpNthJG16dwvpsBjKE14Yc/pbA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/lodash": {
       "version": "4.14.123",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.123.tgz",
@@ -120,6 +136,14 @@
       "version": "11.13.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.4.tgz",
       "integrity": "sha512-+rabAZZ3Yn7tF/XPGHupKIL5EcAbrLxnTr/hgQICxbeuAfWtT0UZSfULE+ndusckBItcv4o6ZeOJplQikVcLvQ=="
+    },
+    "@types/node-jose": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node-jose/-/node-jose-1.1.0.tgz",
+      "integrity": "sha512-ws1RJCQmIDww6/OEW1WcLCqDXZmNMWLoGgW5TEIR7pqJDaGrOkgH8hVw96Wx4rmu65r3/ZiDsb9LjpoizAnlww==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/shelljs": {
       "version": "0.8.4",
@@ -274,6 +298,11 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -289,6 +318,11 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -550,6 +584,14 @@
         "xtend": "^4.0.0"
       }
     },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -598,6 +640,11 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-promise": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
+      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -952,11 +999,47 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      }
+    },
     "just-extend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
       "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
       "dev": true
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "lcid": {
       "version": "2.0.0",
@@ -993,8 +1076,7 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
-      "dev": true
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash._arraycopy": {
       "version": "3.0.0",
@@ -1066,6 +1148,11 @@
         "lodash._bindcallback": "^3.0.0"
       }
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -1078,6 +1165,31 @@
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
     "lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
@@ -1088,6 +1200,11 @@
         "lodash.isarguments": "^3.0.0",
         "lodash.isarray": "^3.0.0"
       }
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.toarray": {
       "version": "4.4.0",
@@ -1109,6 +1226,11 @@
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-3.1.0.tgz",
       "integrity": "sha512-zFo5MgCJ0rZ7gQg69S4pqBsLURbFw11X68C18OcJjJQbqaXm2NoTrGl1IMM3TIz0/BnN1tIs2tzmmqvCsOMMjw==",
       "dev": true
+    },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
     },
     "loud-rejection": {
       "version": "1.6.0",
@@ -1324,6 +1446,24 @@
       "dev": true,
       "requires": {
         "object.getownpropertydescriptors": "^2.0.3"
+      }
+    },
+    "node-forge": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.2.tgz",
+      "integrity": "sha512-mXQ9GBq1N3uDCyV1pdSzgIguwgtVpM7f5/5J4ipz12PKWElmPpVWLDuWl8iXmhysr21+WmX/OJ5UKx82wjomgg=="
+    },
+    "node-jose": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/node-jose/-/node-jose-1.1.3.tgz",
+      "integrity": "sha512-kupfi4uGWhRjnOmtie2T64cLge5a1TZyalEa8uWWWBgtKBcu41A4IGKpI9twZAxRnmviamEUQRK7LSyfFb2w8A==",
+      "requires": {
+        "base64url": "^3.0.1",
+        "es6-promise": "^4.2.6",
+        "lodash": "^4.17.11",
+        "long": "^4.0.0",
+        "node-forge": "^0.8.1",
+        "uuid": "^3.3.2"
       }
     },
     "node-notifier": {
@@ -1687,11 +1827,15 @@
         "glob": "^7.1.3"
       }
     },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
     "semver": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
-      "dev": true
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
     },
     "set-blocking": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,19 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@rdfjs/data-model": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.1.1.tgz",
+      "integrity": "sha512-4jb1zc77f27u/MLVhpE/zHR1uvdH4XElXG63rJP/kVnvKoHtVfyJSEqN9oRLANgqHJ9SNwKj9FXeNFZ4+GGfiw==",
+      "requires": {
+        "@types/rdf-js": "^2.0.1"
+      }
+    },
+    "@rdfjs/to-ntriples": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-1.0.1.tgz",
+      "integrity": "sha512-fgVEDptGdErQX6PMztNsSG0CECt4HDBs6oo0J7fbg0PDCRVTJQITnbEANZnYxx01sSW4zu7fKBmfVfCFlxppPQ=="
+    },
     "@sinonjs/commons": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
@@ -141,6 +154,14 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@types/node-jose/-/node-jose-1.1.0.tgz",
       "integrity": "sha512-ws1RJCQmIDww6/OEW1WcLCqDXZmNMWLoGgW5TEIR7pqJDaGrOkgH8hVw96Wx4rmu65r3/ZiDsb9LjpoizAnlww==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/rdf-js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-2.0.1.tgz",
+      "integrity": "sha512-x3Qct8TPilUos4znM1gANmtTvjOFdDRItmpEM2Nu9QgAx258FN9k22OvOu2TmPzOlx8a1FLdEW3o33UXHQt5ow==",
       "requires": {
         "@types/node": "*"
       }
@@ -480,6 +501,11 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -878,8 +904,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "interpret": {
       "version": "1.2.0",
@@ -1397,6 +1422,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
       "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
+    "n3": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-0.11.3.tgz",
+      "integrity": "sha512-Hk5GSXBeAZrYoqi+NeS/U0H47Hx0Lzj7K6nLWCZpC9E04iUwEwBcrlMb/5foAli7QF4newPNQQQGgM6IAxTxGg=="
+    },
     "neo-async": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
@@ -1702,6 +1732,11 @@
         "pinkie": "^2.0.0"
       }
     },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -1716,6 +1751,68 @@
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "rdf-data-model": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-data-model/-/rdf-data-model-1.0.0.tgz",
+      "integrity": "sha1-52jhws2QTBhkcbINGk/Od8dxKks="
+    },
+    "rdf-dataset-indexed": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/rdf-dataset-indexed/-/rdf-dataset-indexed-0.3.0.tgz",
+      "integrity": "sha512-EmirAFF3T+7E/uNXcBSHrQdmYPcZzLFCOTOCvplE/0G9fmqpbQ+TEmIQQTZAW+hQtT34mIzq6a7UVjLgJuznRg==",
+      "requires": {
+        "@rdfjs/data-model": "^1.1.1",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "rdf-ext": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rdf-ext/-/rdf-ext-1.2.2.tgz",
+      "integrity": "sha512-GnZo8OshYy3A/sKv/o1Hnrsmo+Jclb5qfQFvjvjIirQpypylkx6lm/F2P5ongk/myzSn+zORWETuhsjNPvvUtw==",
+      "requires": {
+        "@rdfjs/data-model": "^1.1.0",
+        "@rdfjs/to-ntriples": "^1.0.1",
+        "rdf-dataset-indexed": "^0.3.0",
+        "rdf-normalize": "^1.0.0"
+      }
+    },
+    "rdf-normalize": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-normalize/-/rdf-normalize-1.0.0.tgz",
+      "integrity": "sha1-U0lrrzYszp2fyh8iFsbDAAf5nMo="
+    },
+    "rdf-parser-n3": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/rdf-parser-n3/-/rdf-parser-n3-1.1.1.tgz",
+      "integrity": "sha512-0fmITANt/DcOB9in1ZuVaLBDwmsaKhhe4MQMVovWE4VBA1Jw/6UHXrmJsB+DS5Gqa7KtQdIIFTNCbArJKujQcw==",
+      "requires": {
+        "n3": "^0.11.2",
+        "rdf-data-model": "^1.0.0",
+        "rdf-sink": "^1.0.0",
+        "readable-stream": "^2.2.9"
+      }
+    },
+    "rdf-sink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-sink/-/rdf-sink-1.0.1.tgz",
+      "integrity": "sha512-AytWds7C3HdYOr0nLpLcqvaPnbNFMlZ+u3gccYPzISxBvByMIfMzKbMbCzjQTZVmnVMEfCzACm2+MXeASAACAg==",
+      "requires": {
+        "rdf-ext": "^1.1.0",
+        "readable-stream": "^2.3.5"
       }
     },
     "read-pkg": {
@@ -1756,6 +1853,35 @@
           "dev": true,
           "requires": {
             "pinkie-promise": "^2.0.0"
+          }
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -1969,6 +2095,14 @@
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
+      "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -2265,6 +2399,11 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2122,6 +2122,11 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "@types/debug": "^4.1.3",
     "@types/node": "^11.12.1",
-    "debug": "^4.1.1"
+    "debug": "^4.1.1",
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "jsonwebtoken": "^8.5.1",
     "jws": "^3.2.2",
     "node-jose": "^1.1.3",
+    "rdf-parser-n3": "^1.1.1",
     "uuid": "^3.3.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,14 @@
   "main": "dist/app.js",
   "dependencies": {
     "@types/debug": "^4.1.3",
+    "@types/jsonwebtoken": "^8.3.2",
+    "@types/jws": "^3.2.0",
     "@types/node": "^11.12.1",
+    "@types/node-jose": "^1.1.0",
     "debug": "^4.1.1",
+    "jsonwebtoken": "^8.5.1",
+    "jws": "^3.2.2",
+    "node-jose": "^1.1.3",
     "uuid": "^3.3.2"
   },
   "devDependencies": {

--- a/src/Blob.ts
+++ b/src/Blob.ts
@@ -1,0 +1,6 @@
+import { Node } from './Node'
+
+export interface Blob extends Node {
+  getData (): Promise<any>
+  setData (data: any): Promise<void>
+}

--- a/src/BlobTree.ts
+++ b/src/BlobTree.ts
@@ -1,0 +1,23 @@
+import { Container } from './Container'
+import { Blob } from './Blob'
+
+export class Path {
+  parts: Array<string>
+  constructor (str: string) {
+    this.parts = str.split('/').filter(x => !!x.length)
+  }
+  asString (): string {
+    return this.parts.join('/')
+  }
+}
+
+// throws:
+// sub-blob attempt
+// getData/setData when doesn't exist
+// containers always exist, unless there is a blob at their filename
+// creating a path ignores the trailing slash
+export interface BlobTree {
+  getContainer (path: Path): Container
+  getBlob (path: Path): Blob
+  on (eventName: string, eventHandler: (event: any) => void): void
+}

--- a/src/BlobTree.ts
+++ b/src/BlobTree.ts
@@ -3,11 +3,22 @@ import { Blob } from './Blob'
 
 export class Path {
   parts: Array<string>
-  constructor (str: string) {
-    this.parts = str.split('/').filter(x => !!x.length)
+  constructor (arg: string | Array<string>) {
+    if (Array.isArray(arg)) {
+      this.parts = arg
+    } else {
+      this.parts = arg.split('/').filter(x => !!x.length)
+    }
   }
   asString (): string {
     return this.parts.join('/')
+  }
+  parentNode (): Path | undefined {
+    if (this.parts.length === 0) {
+      return undefined
+    }
+    const parentParts = this.parts.slice(0, this.parts.length - 1)
+    return new Path(parentParts)
   }
 }
 

--- a/src/BlobTreeInMem.ts
+++ b/src/BlobTreeInMem.ts
@@ -1,0 +1,104 @@
+import Debug from 'debug'
+import { Node } from './Node'
+import { Container } from './Container'
+import { Blob } from './Blob'
+import { BlobTree, Path } from './BlobTree'
+
+const debug = Debug('AtomicTreeInMem')
+
+class NodeInMem {
+  path: Path
+  tree: BlobTreeInMem
+
+  constructor (path: Path, tree: BlobTreeInMem) {
+    this.path = path
+    this.tree = tree
+    debug('constructed node', path, tree)
+  }
+  exists () {
+    throw new Error('overwrite me')
+  }
+}
+
+const PLACEHOLDER_MEMBER_NAME = '.placeholder'
+
+class ContainerInMem extends NodeInMem implements Container {
+  getDescendents () {
+    const containerPathPrefix = this.path.asString() + '/'
+    return Object.keys(this.tree.kv).filter(x => {
+      return (x.length > containerPathPrefix.length)
+    }).filter(x => {
+      return (x.substr(0, containerPathPrefix.length) === containerPathPrefix
+      )
+    })
+  }
+  getMembers () {
+    const listAbsolutePaths = this.getDescendents()
+    const prefixLength = this.path.asString().length + 1
+    const listRelativePaths = listAbsolutePaths.map(x => x.substring(prefixLength))
+    const distinct = (value, index, self) => {
+      return self.indexOf(value) === index
+    }
+    const memberNames = listRelativePaths.map(x => {
+      const parts = x.split('/')
+      if (parts.length === 1) { // member blob
+        return x
+      } else {
+        return parts[0] + '/'
+      }
+    }).filter(distinct).filter(x => (x !== PLACEHOLDER_MEMBER_NAME))
+    debug('getMembers', this.path, this.tree.kv, listAbsolutePaths, listRelativePaths, memberNames)
+    return Promise.resolve(memberNames)
+  }
+  delete () {
+    this.getDescendents().map(x => {
+      delete this.tree.kv[x]
+    })
+    return Promise.resolve()
+  }
+  exists () {
+    debug('checking exists', this.path.asString(), Object.keys(this.tree.kv))
+    return (!!this.getDescendents().length)
+  }
+}
+
+class BlobInMem extends NodeInMem implements Blob {
+  getData () {
+    debug('reading resource', this.path, this.tree.kv)
+    return Promise.resolve(this.tree.kv[this.path.asString()])
+  }
+  setData (data: Buffer) {
+    debug('setData', this.path)
+    this.tree.kv[this.path.asString()] = data
+    debug('this.tree.kv after setData', this.tree.kv, this.path, this.path.asString())
+    return Promise.resolve()
+  }
+  delete () {
+    delete this.tree.kv[this.path.asString()]
+    return Promise.resolve()
+  }
+  exists () {
+    debug('checking exists', this.path.asString(), Object.keys(this.tree.kv))
+    return (!!this.tree.kv.hasOwnProperty(this.path.asString()))
+  }
+}
+
+export default class BlobTreeInMem {
+  kv: any
+
+  constructor () {
+    this.kv = {}
+    debug('constructed in-mem store', this.kv)
+  }
+
+  getContainer (path: Path) {
+    return new ContainerInMem(path, this)
+  }
+  getBlob (path: Path) {
+    return new BlobInMem(path, this)
+  }
+  on (eventName: string, eventHandler: (event: any) => void) {
+    // TODO: implement
+    debug('adding event handler', eventName, eventHandler)
+  }
+}

--- a/src/Container.ts
+++ b/src/Container.ts
@@ -1,0 +1,5 @@
+import { Node } from './Node'
+
+export interface Container extends Node {
+  getMembers (): Promise<Array<string>>
+}

--- a/src/Node.ts
+++ b/src/Node.ts
@@ -1,0 +1,4 @@
+export interface Node {
+  exists (): boolean,
+  delete (): Promise<void>
+}

--- a/src/ResourceData.ts
+++ b/src/ResourceData.ts
@@ -1,0 +1,15 @@
+// import * as Stream from 'stream'
+import calculateETag from './calculateETag'
+
+export interface ResourceData {
+  body: string
+  contentType: string
+  etag: string
+}
+export function makeResourceData (contentType: string, body: string): ResourceData {
+  return {
+    contentType,
+    body,
+    etag: calculateETag(body)
+  }
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,0 +1,69 @@
+import * as http from 'http'
+import Debug from 'debug'
+const debug = Debug('app')
+
+import { BlobTree } from './BlobTree'
+import { LdpParser, LdpTask, TaskType } from './processors/LdpParser'
+
+import { ContainerReader } from './processors/ContainerReader'
+import { ContainerMemberAdder } from './processors/ContainerMemberAdder'
+import { ContainerDeleter } from './processors/ContainerDeleter'
+
+import { GlobReader } from './processors/GlobReader'
+
+import { BlobReader } from './processors/BlobReader'
+import { BlobWriter } from './processors/BlobWriter'
+import { BlobUpdater } from './processors/BlobUpdater'
+import { BlobDeleter } from './processors/BlobDeleter'
+
+import { Responder, LdpResponse } from './processors/Responder'
+import Processor from './processors/Processor'
+
+export default (storage: BlobTree) => {
+  const processors = {
+    // step 1, parse:
+    // input type: http.IncomingMessage
+    // output type: LdpTask
+    parseLdp: new LdpParser(),
+
+    // step 2, execute:
+    // input type: LdpTask
+    // output type: LdpResponse
+    [TaskType.containerRead]: new ContainerReader(storage),
+    [TaskType.containerDelete]: new ContainerDeleter(storage),
+    [TaskType.containerMemberAdd]: new ContainerMemberAdder(storage),
+    [TaskType.globRead]: new GlobReader(storage),
+    [TaskType.blobRead]: new BlobReader(storage),
+    [TaskType.blobWrite]: new BlobWriter(storage),
+    [TaskType.blobUpdate]: new BlobUpdater(storage),
+    [TaskType.blobDelete]: new BlobDeleter(storage),
+
+    // step 3, handle result:
+    // input type: LdpResponse
+    // output type: void
+    respondAndRelease: new Responder()
+  }
+
+  const handle = async (req: http.IncomingMessage, res: http.ServerResponse) => {
+    debug(`\n\n`, req.method, req.url, req.headers)
+
+    let response: LdpResponse
+    try {
+      const ldpTask: LdpTask = await processors.parseLdp.process(req)
+      debug('parsed', ldpTask)
+      const requestProcessor: Processor = processors[ldpTask.ldpTaskType]
+      response = await requestProcessor.process(ldpTask)
+      debug('executed', response)
+    } catch (error) {
+      debug('errored', error)
+      response = error as LdpResponse
+    }
+    response.httpRes = res
+    try {
+      return processors.respondAndRelease.process(response)
+    } catch (error) {
+      debug('errored while responding', error)
+    }
+  }
+  return handle
+}

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ const debug = Debug('app')
 
 import { BlobTree } from './BlobTree'
 import { LdpParser, LdpTask, TaskType } from './processors/LdpParser'
+import { DetermineWebId } from './processors/DetermineWebId'
 
 import { ContainerReader } from './processors/ContainerReader'
 import { ContainerMemberAdder } from './processors/ContainerMemberAdder'
@@ -25,7 +26,7 @@ export default (storage: BlobTree) => {
     // input type: http.IncomingMessage
     // output type: LdpTask
     parseLdp: new LdpParser(),
-
+    determineWebId: new DetermineWebId(),
     // step 2, execute:
     // input type: LdpTask
     // output type: LdpResponse
@@ -51,6 +52,8 @@ export default (storage: BlobTree) => {
     try {
       const ldpTask: LdpTask = await processors.parseLdp.process(req)
       debug('parsed', ldpTask)
+      const webId = await processors.determineWebId.process(ldpTask)
+      debug('webId', webId)
       const requestProcessor: Processor = processors[ldpTask.ldpTaskType]
       response = await requestProcessor.process(ldpTask)
       debug('executed', response)

--- a/src/app.ts
+++ b/src/app.ts
@@ -19,6 +19,7 @@ import { BlobDeleter } from './processors/BlobDeleter'
 
 import { Responder, LdpResponse } from './processors/Responder'
 import Processor from './processors/Processor'
+import { AclReader } from './processors/AclReader'
 
 export default (storage: BlobTree) => {
   const processors = {
@@ -27,6 +28,8 @@ export default (storage: BlobTree) => {
     // output type: LdpTask
     parseLdp: new LdpParser(),
     determineWebId: new DetermineWebId(),
+    readAcl: new AclReader(storage),
+
     // step 2, execute:
     // input type: LdpTask
     // output type: LdpResponse
@@ -54,6 +57,8 @@ export default (storage: BlobTree) => {
       debug('parsed', ldpTask)
       const webId = await processors.determineWebId.process(ldpTask)
       debug('webId', webId)
+      const aclGraph = await processors.readAcl.process(ldpTask.path)
+      debug('aclGraph', aclGraph)
       const requestProcessor: Processor = processors[ldpTask.ldpTaskType]
       response = await requestProcessor.process(ldpTask)
       debug('executed', response)

--- a/src/calculateETag.ts
+++ b/src/calculateETag.ts
@@ -1,0 +1,9 @@
+import * as crypto from 'crypto'
+
+const secret = 'abcdefg'
+
+export default function calculateETag (text: string) {
+  const hmac = crypto.createHmac('sha256', secret)
+  hmac.update(text)
+  return hmac.digest('hex')
+}

--- a/src/membersListAsResourceData.ts
+++ b/src/membersListAsResourceData.ts
@@ -1,0 +1,46 @@
+import * as Stream from 'stream'
+import Debug from 'debug'
+import { makeResourceData, ResourceData } from './ResourceData'
+const debug = Debug('membersListAsResourceData')
+
+const NEWLINE = '\r\n'
+
+function toTurtle (containerUrl: string, fileNames: Array<string>): string {
+  debug('folderDescription', fileNames)
+
+  const prefixes = [
+    '@prefix ldp: <http://www.w3.org/ns/ldp#>.'
+  ]
+  const memberRefs = fileNames.map(filename => `<${filename}>`)
+  const containerItem = [
+    `<${containerUrl}>`,
+    `    ldp:contains ${memberRefs.join(', ')};`
+  ].join(NEWLINE)
+  return [
+    prefixes.join(NEWLINE),
+    containerItem
+  ].join(NEWLINE + NEWLINE) + NEWLINE
+}
+
+function toJsonLd (containerUrl: string, fileNames: Array<string>): string {
+  return JSON.stringify({
+    '@id': containerUrl,
+    'contains': fileNames.map(fileName => containerUrl + fileName),
+    '@context': {
+      'contains': {
+        '@id': 'http://www.w3.org/ns/ldp#contains',
+        '@type': '@id'
+      },
+      'ldp': 'http://www.w3.org/ns/ldp#'
+    }
+  })
+}
+
+export default function membersListAsResourceData (containerUrl, fileNames, asJsonLd): ResourceData {
+  debug('membersListAsResourceData', containerUrl, fileNames, asJsonLd)
+  if (asJsonLd) {
+    return makeResourceData('application/ld+json', toJsonLd(containerUrl, fileNames))
+  } else {
+    return makeResourceData('text/turtle', toTurtle(containerUrl, fileNames))
+  }
+}

--- a/src/processors/AclReader.ts
+++ b/src/processors/AclReader.ts
@@ -1,0 +1,61 @@
+import Debug from 'debug'
+import rdf from 'rdf-ext'
+import N3Parser from 'rdf-parser-n3'
+
+import StorageProcessor from './StorageProcessor'
+import Processor from './Processor'
+import { Path } from '../BlobTree'
+import { Blob } from '../Blob'
+import { ResourceData, makeResourceData } from '../ResourceData'
+
+export class AclReader extends StorageProcessor implements Processor {
+  async getAclBlob (resourcePath: Path): Promise<ResourceData> {
+    let currentGuessPath = resourcePath
+    let currentGuessBlob = this.storage.getBlob(new Path(currentGuessPath.asString() + '.acl'))
+    while (!currentGuessBlob.exists()) {
+      currentGuessPath = currentGuessPath.parentNode()
+      if (!currentGuessPath) {
+        // root ACL, nobody has access:
+        return makeResourceData('text/turtle', '')
+      }
+      let currentGuessBlob = this.storage.getBlob(new Path(currentGuessPath.asString() + '.acl'))
+    }
+    return currentGuessBlob.getData()
+  }
+
+  async process (resourcePath: Path) {
+    const aclResourceData = await this.getAclBlob(resourcePath)
+    let parser = new N3Parser({
+      factory: rdf
+    })
+    let quadStream = parser.import(aclResourceData.body)
+    const dataset = await rdf.dataset().import(quadStream)
+    return dataset
+  }
+}
+
+// Example ACL file, this one is on https://michielbdejong.inrupt.net/.acl:
+//
+// # Root ACL resource for the user account
+// @prefix acl: <http://www.w3.org/ns/auth/acl#>.
+
+// <#owner>
+//     a acl:Authorization;
+
+//     acl:agent <https://michielbdejong.inrupt.net/profile/card#me> ;
+
+//     # Optional owner email, to be used for account recovery:
+//     acl:agent <mailto:michiel@unhosted.org>;
+
+//     # Set the access to the root storage folder itself
+//     acl:accessTo </>;
+
+//     # All resources will inherit this authorization, by default
+//     acl:defaultForNew </>;
+
+//     # The owner has all of the access modes allowed
+//     acl:mode
+//         acl:Read, acl:Write, acl:Control.
+
+// # Data is private by default; no other agents get access unless specifically
+// # authorized in other .acls

--- a/src/processors/BlobDeleter.ts
+++ b/src/processors/BlobDeleter.ts
@@ -1,0 +1,27 @@
+import Debug from 'debug'
+import StorageProcessor from './StorageProcessor'
+import Processor from './Processor'
+import { LdpResponse, ResultType } from './Responder'
+import { LdpTask } from './LdpParser'
+
+const debug = Debug('ResourceDeleter')
+
+export class BlobDeleter extends StorageProcessor implements Processor {
+  async process (task: LdpTask) {
+    debug('LdpParserResult ResourceDeleter!')
+    const resource = this.storage.getBlob(task.path)
+    // FIXME: duplicate code with ResourceWriter. use inheritence with common ancestor?
+    if (task.ifMatch) {
+      const resourceData = await resource.getData()
+      if (resourceData.etag !== task.ifMatch) {
+        return {
+          resultType: ResultType.PreconditionFailed
+        } as LdpResponse
+      }
+    }
+    await resource.delete()
+    return {
+      resultType: ResultType.OkayWithoutBody
+    } as LdpResponse
+  }
+}

--- a/src/processors/BlobReader.ts
+++ b/src/processors/BlobReader.ts
@@ -1,0 +1,36 @@
+import Debug from 'debug'
+import StorageProcessor from './StorageProcessor'
+import Processor from './Processor'
+import { LdpResponse, ResultType } from './Responder'
+import { LdpTask } from './LdpParser'
+import { Blob } from '../Blob'
+
+const debug = Debug('ResourceReader')
+
+export class BlobReader extends StorageProcessor implements Processor {
+  async executeTask (task: LdpTask, resource: Blob): Promise<LdpResponse> {
+    let result = {
+    } as any
+    if (!resource.exists()) {
+      result.resultType = ResultType.NotFound
+      return result
+    }
+    result.resourceData = await resource.getData()
+    debug('result.resourceData set to ', result.resourceData)
+    if (task.omitBody) {
+      result.resultType = ResultType.OkayWithoutBody
+    } else if (task.ifNoneMatch && task.ifNoneMatch.indexOf(result.resourceData.etag) !== -1) {
+      result.resultType = ResultType.NotModified
+    } else {
+      result.resultType = ResultType.OkayWithBody
+    }
+    return result as LdpResponse
+  }
+
+  async process (task: LdpTask) {
+    debug('LdpParserResult ResourceReader!')
+    const resource = this.storage.getBlob(task.path)
+    const result = await this.executeTask(task, resource)
+    return result
+  }
+}

--- a/src/processors/BlobUpdater.ts
+++ b/src/processors/BlobUpdater.ts
@@ -1,0 +1,17 @@
+import Debug from 'debug'
+import StorageProcessor from './StorageProcessor'
+import Processor from './Processor'
+import { LdpResponse, ResultType } from './Responder'
+import { LdpTask } from './LdpParser'
+
+const debug = Debug('ResourceUpdater')
+
+export class BlobUpdater extends StorageProcessor implements Processor {
+  async process (task: LdpTask) {
+    debug('LdpParserResult ResourceUpdater!')
+    // TODO: implement
+    return {
+      resultType: ResultType.OkayWithoutBody
+    } as LdpResponse
+  }
+}

--- a/src/processors/BlobWriter.ts
+++ b/src/processors/BlobWriter.ts
@@ -1,0 +1,29 @@
+import Debug from 'debug'
+import StorageProcessor from './StorageProcessor'
+import Processor from './Processor'
+import { LdpResponse, ResultType } from './Responder'
+import { LdpTask } from './LdpParser'
+import { makeResourceData } from '../ResourceData'
+
+const debug = Debug('ResourceWriter')
+
+export class BlobWriter extends StorageProcessor implements Processor {
+  async process (task: LdpTask) {
+    debug('LdpParserResult ResourceWriter!')
+    const resource = this.storage.getBlob(task.path)
+    // FIXME: duplicate code with ResourceWriter. use inheritence with common ancestor?
+    if (task.ifMatch) {
+      const resourceData = await resource.getData()
+      if (resourceData.etag !== task.ifMatch) {
+        return {
+          resultType: ResultType.PreconditionFailed
+        } as LdpResponse
+      }
+    }
+    const resultType = (resource.exists() ? ResultType.OkayWithoutBody : ResultType.Created)
+    await resource.setData(Buffer.from(JSON.stringify(makeResourceData(task.contentType, task.requestBody))))
+    return {
+      resultType
+    } as LdpResponse
+  }
+}

--- a/src/processors/ContainerDeleter.ts
+++ b/src/processors/ContainerDeleter.ts
@@ -1,0 +1,19 @@
+import Debug from 'debug'
+import StorageProcessor from './StorageProcessor'
+import Processor from './Processor'
+import { LdpResponse, ResultType } from './Responder'
+import { LdpTask } from './LdpParser'
+
+const debug = Debug('ContainerDeleter')
+
+export class ContainerDeleter extends StorageProcessor implements Processor {
+  async process (task: LdpTask) {
+    debug('LdpParserResult ContainerDeleter!')
+    const container = this.storage.getBlob(task.path)
+    // TODO: check task.ifMatch
+    await container.delete()
+    return {
+      resultType: ResultType.OkayWithoutBody
+    } as LdpResponse
+  }
+}

--- a/src/processors/ContainerMemberAdder.ts
+++ b/src/processors/ContainerMemberAdder.ts
@@ -1,0 +1,22 @@
+import Debug from 'debug'
+import StorageProcessor from './StorageProcessor'
+import Processor from './Processor'
+import { LdpResponse, ResultType } from './Responder'
+import { LdpTask } from './LdpParser'
+import uuid from 'uuid/v4'
+import { makeResourceData } from '../ResourceData'
+
+const debug = Debug('ContainerMemberAdder')
+
+export class ContainerMemberAdder extends StorageProcessor implements Processor {
+  async process (task: LdpTask) {
+    debug('LdpParserResult ContainerMemberAdder!')
+    const resourcePath = task.path + uuid()
+    const resource = this.storage.getBlob(resourcePath)
+    await resource.setData(makeResourceData(task.contentType, task.requestBody))
+    return {
+      resultType: ResultType.Created,
+      createdLocation: resourcePath
+    } as LdpResponse
+  }
+}

--- a/src/processors/ContainerReader.ts
+++ b/src/processors/ContainerReader.ts
@@ -1,0 +1,24 @@
+import Debug from 'debug'
+import StorageProcessor from './StorageProcessor'
+import Processor from './Processor'
+import { LdpResponse, ResultType } from './Responder'
+import { LdpTask } from './LdpParser'
+import membersListAsResourceData from '../membersListAsResourceData'
+
+const debug = Debug('ContainerReader')
+
+export class ContainerReader extends StorageProcessor implements Processor {
+  async process (task: LdpTask) {
+    const container = this.storage.getContainer(task.path)
+    const membersList = await container.getMembers()
+    const resourceData = membersListAsResourceData(task.path, membersList, task.asJsonLd)
+    return {
+      resultType: (task.omitBody ? ResultType.OkayWithoutBody : ResultType.OkayWithBody),
+      resourceData,
+      createdLocation: undefined,
+      isContainer: task.isContainer,
+      lock: container,
+      httpRes: undefined
+    } as LdpResponse
+  }
+}

--- a/src/processors/DetermineAllowedModesForAgent.ts
+++ b/src/processors/DetermineAllowedModesForAgent.ts
@@ -13,15 +13,20 @@ export interface AgentCheckTask {
   aclGraph: any
 }
 
-export enum AccessMode {
-  read,
-  write,
-  append,
-  control
+export interface AccessModes {
+  read: Boolean
+  write: Boolean
+  append: Boolean
+  control: Boolean
 }
 
 export class DetermineAllowedModeForAgent extends StorageProcessor implements Processor {
-  async process (task: AgentCheckTask): Promise<Array<AccessMode>> {
-    return []
+  async process (task: AgentCheckTask): Promise<AccessModes> {
+    return {
+      read: false,
+      write: false,
+      append: false,
+      control: false
+    }
   }
 }

--- a/src/processors/DetermineAllowedModesForAgent.ts
+++ b/src/processors/DetermineAllowedModesForAgent.ts
@@ -1,0 +1,27 @@
+import jose from 'node-jose'
+import jws from 'jws'
+import jwt from 'jsonwebtoken'
+import Processor from './Processor'
+import Debug from 'debug'
+import { LdpTask } from './LdpParser'
+import StorageProcessor from './StorageProcessor'
+
+const debug = Debug('DetermineAllowedModeForAgent')
+
+export interface AgentCheckTask {
+  agent: string,
+  aclGraph: any
+}
+
+export enum AccessMode {
+  read,
+  write,
+  append,
+  control
+}
+
+export class DetermineAllowedModeForAgent extends StorageProcessor implements Processor {
+  async process (task: AgentCheckTask): Promise<Array<AccessMode>> {
+    return []
+  }
+}

--- a/src/processors/DetermineAllowedModesForOrigin.ts
+++ b/src/processors/DetermineAllowedModesForOrigin.ts
@@ -5,7 +5,7 @@ import Processor from './Processor'
 import Debug from 'debug'
 import { LdpTask } from './LdpParser'
 import StorageProcessor from './StorageProcessor'
-import { AccessMode } from './DetermineAllowedModesForAgent'
+import { AccessModes } from './DetermineAllowedModesForAgent'
 
 const debug = Debug('DetermineAllowedModeForAgent')
 
@@ -15,7 +15,12 @@ export interface OriginCheckTask {
 }
 
 export class DetermineAllowedModeForOrigin extends StorageProcessor implements Processor {
-  async process (task: OriginCheckTask): Promise<Array<AccessMode>> {
-    return []
+  async process (task: OriginCheckTask): Promise<AccessModes> {
+    return {
+      read: false,
+      write: false,
+      append: false,
+      control: false
+    }
   }
 }

--- a/src/processors/DetermineAllowedModesForOrigin.ts
+++ b/src/processors/DetermineAllowedModesForOrigin.ts
@@ -1,0 +1,21 @@
+import jose from 'node-jose'
+import jws from 'jws'
+import jwt from 'jsonwebtoken'
+import Processor from './Processor'
+import Debug from 'debug'
+import { LdpTask } from './LdpParser'
+import StorageProcessor from './StorageProcessor'
+import { AccessMode } from './DetermineAllowedModesForAgent'
+
+const debug = Debug('DetermineAllowedModeForAgent')
+
+export interface OriginCheckTask {
+  origin: string,
+  aclGraph: any
+}
+
+export class DetermineAllowedModeForOrigin extends StorageProcessor implements Processor {
+  async process (task: OriginCheckTask): Promise<Array<AccessMode>> {
+    return []
+  }
+}

--- a/src/processors/DetermineWebId.ts
+++ b/src/processors/DetermineWebId.ts
@@ -1,0 +1,27 @@
+import jose from 'node-jose'
+import jws from 'jws'
+import jwt from 'jsonwebtoken'
+import Processor from './Processor'
+import Debug from 'debug'
+import { LdpTask } from './LdpParser'
+
+const debug = Debug('DetermineWebId')
+
+export class DetermineWebId implements Processor {
+  async process (task: LdpTask): Promise<string> {
+    try {
+      debug('bearerToken before decoding', task.bearerToken)
+      const decodedBearerToken = jws.decode(task.bearerToken)
+      debug('bearerToken after decoding', decodedBearerToken)
+      const payload = JSON.parse(decodedBearerToken.payload)
+      debug('JSON-parsed payload in the decoded bearer token', payload)
+      const idToken = jwt.decode(payload.id_token)
+      debug('payload.id_token after decoding', idToken)
+      // TODO: verify signature!
+      debug('skipped signature checking for now; returning idToken.sub')
+      return idToken.sub
+    } catch (error) {
+      debug(error)
+    }
+  }
+}

--- a/src/processors/GlobReader.ts
+++ b/src/processors/GlobReader.ts
@@ -1,0 +1,17 @@
+import Debug from 'debug'
+import StorageProcessor from './StorageProcessor'
+import Processor from './Processor'
+import { LdpResponse, ResultType } from './Responder'
+import { LdpTask } from './LdpParser'
+
+const debug = Debug('GlobReader')
+
+export class GlobReader extends StorageProcessor implements Processor {
+  async process (task: LdpTask) {
+    debug('LdpParserResult GlobReader!')
+    // TODO: implement
+    return {
+      resultType: ResultType.OkayWithBody
+    } as LdpResponse
+  }
+}

--- a/src/processors/LdpParser.ts
+++ b/src/processors/LdpParser.ts
@@ -115,6 +115,15 @@ export class LdpParser implements Processor {
     }
   }
 
+  determineAccessToken (httpReq: http.IncomingMessage): string | undefined {
+    try {
+      return httpReq.headers['authorization'].substring('Bearer '.length)
+    } catch (error) {
+      debug('no bearer token found') // TODO: allow other ways of providing a PoP token
+    }
+    return undefined
+  }
+
   async process (httpReq: http.IncomingMessage) {
     debug('LdpParserTask!')
     let errorCode = null // todo actually use this. maybe with try-catch?
@@ -128,6 +137,7 @@ export class LdpParser implements Processor {
       ifNoneMatch: this.determineIfNoneMatch(httpReq),
       asJsonLd: this.determineAsJsonLd(httpReq),
       ldpTaskType: this.determineTaskType(httpReq),
+      bearerToken: this.determineAccessToken(httpReq),
       requestBody: undefined,
       path: new Path(httpReq.url)
     } as LdpTask
@@ -166,6 +176,7 @@ export class LdpTask {
   contentType: string | undefined
   ifMatch: string | undefined
   ifNoneMatch: Array<string> | undefined
+  bearerToken: string | undefined
   ldpTaskType: TaskType
   path: Path
   requestBody: string

--- a/src/processors/LdpParser.ts
+++ b/src/processors/LdpParser.ts
@@ -1,0 +1,172 @@
+import * as http from 'http'
+import Debug from 'debug'
+import Processor from './Processor'
+import { LdpResponse, ResultType, ErrorResult } from './Responder'
+import { Path } from '../BlobTree'
+
+const debug = Debug('LdpParser')
+
+export enum TaskType {
+  containerRead,
+  containerMemberAdd,
+  containerDelete,
+  globRead,
+  blobRead,
+  blobWrite,
+  blobUpdate,
+  blobDelete,
+  unknown
+}
+
+// parse the http request to extract some basic info (e.g. is it a container?)
+// and add that info to the request, then pass it on to the colleague from
+// Authentication:
+export class LdpParser implements Processor {
+  getContainerTask (method: string) {
+    if (method === 'OPTIONS' || method === 'HEAD' || method === 'GET') {
+      return TaskType.containerRead
+    }
+    if (method === 'POST' || method === 'PUT') {
+      return TaskType.containerMemberAdd
+    }
+    if (method === 'DELETE') {
+      return TaskType.containerDelete
+    }
+    return TaskType.unknown
+  }
+
+  getGlobTask (method: string) {
+    if (method === 'OPTIONS' || method === 'HEAD' || method === 'GET') {
+      return TaskType.globRead
+    }
+    return TaskType.unknown
+  }
+
+  getBlobTask (method: string) {
+    if (method === 'OPTIONS' || method === 'HEAD' || method === 'GET') {
+      return TaskType.blobRead
+    }
+    if (method === 'PUT') {
+      return TaskType.blobWrite
+    }
+    if (method === 'PUT') {
+      return TaskType.blobUpdate
+    }
+    if (method === 'DELETE') {
+      return TaskType.blobDelete
+    }
+    debug('unknown http method', method)
+    return TaskType.unknown
+  }
+
+  determineTaskType (httpReq: http.IncomingMessage) {
+    // if the URL end with a / then the path indicates a container
+    // if the URL end with /* then the path indicates a glob
+    // in all other cases, the path indicates a blob
+
+    const lastUrlChar = httpReq.url.substr(-1)
+    if (lastUrlChar === '/') {
+      return this.getContainerTask(httpReq.method)
+    } else if (lastUrlChar === '*') {
+      return this.getGlobTask(httpReq.method)
+    } else {
+      return this.getBlobTask(httpReq.method)
+    }
+    return 'containerRead' // todo: implement
+  }
+
+  determineOrigin (httpReq: http.IncomingMessage) {
+    return httpReq.headers.origin
+  }
+
+  determineContentType (httpReq: http.IncomingMessage) {
+    return httpReq.headers['content-type']
+  }
+
+  determineIfMatch (httpReq: http.IncomingMessage) {
+    try {
+      return httpReq.headers['if-match'].split('"')[1]
+    } catch (error) {
+      // return undefined
+    }
+  }
+
+  determineIfNoneMatch (httpReq: http.IncomingMessage) {
+    try {
+      return httpReq.headers['if-none-match'].split(',').map(x => x.split('"')[1])
+    } catch (error) {
+      // return undefined
+    }
+  }
+
+  determineMayIncreaseDiskUsage (httpReq: http.IncomingMessage) {
+    return (['OPTIONS', 'HEAD', 'GET', 'DELETE'].indexOf(httpReq.method) === -1)
+  }
+
+  determineOmitBody (httpReq: http.IncomingMessage) {
+    return (['OPTIONS', 'HEAD'].indexOf(httpReq.method) !== -1)
+  }
+
+  determineAsJsonLd (httpReq: http.IncomingMessage) {
+    try {
+      return (httpReq.headers['content-type'].split(';')[0] === 'application/json+ld')
+    } catch (e) {
+      return false
+    }
+  }
+
+  async process (httpReq: http.IncomingMessage) {
+    debug('LdpParserTask!')
+    let errorCode = null // todo actually use this. maybe with try-catch?
+    const parsedTask = {
+      mayIncreaseDiskUsage: this.determineMayIncreaseDiskUsage(httpReq),
+      omitBody: this.determineOmitBody(httpReq),
+      isContainer: (httpReq.url.substr(-1) === '/'), // FIXME: code duplication, see determineLdpParserResultName above
+      origin: this.determineOrigin(httpReq),
+      contentType: this.determineContentType(httpReq),
+      ifMatch: this.determineIfMatch(httpReq),
+      ifNoneMatch: this.determineIfNoneMatch(httpReq),
+      asJsonLd: this.determineAsJsonLd(httpReq),
+      ldpTaskType: this.determineTaskType(httpReq),
+      requestBody: undefined,
+      path: new Path(httpReq.url)
+    } as LdpTask
+    await new Promise(resolve => {
+      parsedTask.requestBody = ''
+      httpReq.on('data', chunk => {
+        parsedTask.requestBody += chunk
+      })
+      httpReq.on('end', resolve)
+    })
+    debug('parsed http request', {
+      method: httpReq.method,
+      headers: httpReq.headers,
+      mayIncreaseDiskUsage: parsedTask.mayIncreaseDiskUsage,
+      omitBody: parsedTask.omitBody,
+      isContainer: parsedTask.isContainer,
+      origin: parsedTask.origin,
+      ldpTaskType: parsedTask.ldpTaskType,
+      path: parsedTask.path,
+      requestBody: parsedTask.requestBody
+    })
+    if (errorCode === null) {
+      return parsedTask
+    } else {
+      throw new ErrorResult(ResultType.CouldNotParse)
+    }
+  }
+}
+
+export class LdpTask {
+  mayIncreaseDiskUsage: boolean
+  isContainer: boolean
+  omitBody: boolean
+  asJsonLd: boolean
+  origin: string
+  contentType: string | undefined
+  ifMatch: string | undefined
+  ifNoneMatch: Array<string> | undefined
+  ldpTaskType: TaskType
+  path: Path
+  requestBody: string
+}

--- a/src/processors/Processor.ts
+++ b/src/processors/Processor.ts
@@ -1,0 +1,3 @@
+export default interface Processor {
+  process (task: any): Promise<any>
+}

--- a/src/processors/Responder.ts
+++ b/src/processors/Responder.ts
@@ -1,0 +1,113 @@
+import * as http from 'http'
+import Debug from 'debug'
+import Processor from './Processor'
+import { ResourceData } from '../ResourceData'
+const debug = Debug('ResponderAndReleaser')
+
+export enum ResultType {
+  CouldNotParse,
+  AccessDenied,
+  PreconditionFailed,
+  NotModified,
+  NotFound,
+  QuotaExceeded,
+  OkayWithBody,
+  OkayWithoutBody,
+  Created,
+  InternalServerError
+}
+
+export class ErrorResult extends Error {
+  resultType: ResultType
+  constructor (resultType: ResultType) {
+    super('error result')
+    this.resultType = resultType
+  }
+}
+export class LdpResponse {
+  resultType: ResultType
+  resourceData: ResourceData | undefined
+  createdLocation: string | undefined
+  isContainer: boolean
+  httpRes: http.ServerResponse
+}
+
+export class Responder implements Processor {
+  async process (task: LdpResponse) {
+    debug('ResponderAndReleaserTask!')
+
+    const responses = {
+      [ResultType.OkayWithBody]: {
+        responseStatus: 200,
+        responseBody: task.resourceData ? task.resourceData.body : ''
+      },
+      [ResultType.CouldNotParse]: {
+        responseStatus: 405,
+        responseBody: 'Method not allowed'
+      },
+      [ResultType.AccessDenied]: {
+        responseStatus: 401,
+        responseBody: 'Access denied'
+      },
+      [ResultType.PreconditionFailed]: {
+        responseStatus: 412,
+        responseBody: 'Precondition failed'
+      },
+      [ResultType.NotFound]: {
+        responseStatus: 404,
+        responseBody: 'Not found'
+      },
+      [ResultType.NotModified]: {
+        responseStatus: 304,
+        responseBody: 'Not modified'
+      },
+      [ResultType.Created]: {
+        responseStatus: 201,
+        responseBody: 'Created'
+      },
+      [ResultType.OkayWithoutBody]: {
+        responseStatus: 204,
+        responseBody: 'No Content'
+      },
+      [ResultType.InternalServerError]: {
+        responseStatus: 500,
+        responseBody: 'Internal server error'
+      }
+    }
+    debug(task.resultType, responses)
+    const responseStatus = responses[task.resultType].responseStatus
+    const responseBody = responses[task.resultType].responseBody
+
+    const types: Array<string> = [
+      '<http://www.w3.org/ns/ldp#Resource>; rel="type"'
+    ]
+    if (task.isContainer) {
+      types.push('<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"')
+    }
+    const responseHeaders = {
+      'Link': `<.acl>; rel="acl", <.meta>; rel="describedBy", ${types.join(', ')}`,
+      'Allow': 'GET, HEAD, POST, PUT, DELETE, PATCH',
+      'Accept-Patch': 'application/sparql-update',
+      'Accept-Post': 'application/sparql-update'
+    } as any
+    if (task.resourceData) {
+      responseHeaders['Content-Type'] = task.resourceData.contentType
+    }
+    if (task.createdLocation) {
+      responseHeaders['Location'] = task.createdLocation
+    }
+    if (task.resourceData) {
+      debug('setting ETag')
+      responseHeaders.ETag = `"${task.resourceData.etag}"`
+    } else {
+      debug('not setting ETag')
+    }
+
+    debug('responding', { responseStatus, responseHeaders, responseBody })
+    task.httpRes.writeHead(responseStatus, responseHeaders)
+    task.httpRes.end(responseBody)
+    task.httpRes.on('end', () => {
+      debug('request completed')
+    })
+  }
+}

--- a/src/processors/StorageProcessor.ts
+++ b/src/processors/StorageProcessor.ts
@@ -1,0 +1,9 @@
+import { BlobTree } from '../BlobTree'
+
+export default class StorageProcessor {
+  storage: BlobTree
+
+  constructor (storage: BlobTree) {
+    this.storage = storage
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,13 +1,14 @@
 import * as http from 'http'
 import Debug from 'debug'
+import BlobTreeInMem from './BlobTreeInMem'
+import makeHandler from './app'
 
 const debug = Debug('server')
 const port = 8080
 
-const handler = (req, res) => {
-  res.writeHead(200)
-  res.end('todo: implement')
-}
+
+const storage = new BlobTreeInMem() // singleton in-memory storage
+const handler = makeHandler(storage)
 
 const server = http.createServer(handler)
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,7 +6,6 @@ import makeHandler from './app'
 const debug = Debug('server')
 const port = 8080
 
-
 const storage = new BlobTreeInMem() // singleton in-memory storage
 const handler = makeHandler(storage)
 

--- a/test/unit/BlobTreeInMem_test.ts
+++ b/test/unit/BlobTreeInMem_test.ts
@@ -1,0 +1,95 @@
+import { expect } from 'chai'
+import 'mocha'
+import BlobTreeInMem from '../../src/BlobTreeInMem'
+import { BlobTree, Path } from '../../src/BlobTree'
+import { Blob } from '../../src/Blob'
+import { Container } from '../../src/Container'
+
+describe('BlobTreeInMem', () => {
+  beforeEach(function () {
+    // FIXME: find out how to set type restrictions on mocha-context variables
+    this.storage = new BlobTreeInMem()
+  })
+  afterEach(function () {
+    this.storage = undefined
+  })
+  it('adds a blob', async function () {
+    // non-existing blob
+    const blob = this.storage.getBlob(new Path('foo'))
+    expect(blob.exists()).to.equal(false)
+
+    // put data into it
+    await blob.setData(Buffer.from('bar'))
+    expect(blob.exists()).to.equal(true)
+    const readBack2 = await blob.getData()
+    expect(readBack2.toString()).to.equal('bar')
+  })
+
+  it('adds a container', async function () {
+    // non-existing container
+    const container = this.storage.getContainer(new Path('foo/'))
+    expect(container.exists()).to.equal(false)
+
+    // add a member
+    const blob = this.storage.getBlob(new Path('foo/bar'))
+    await blob.setData(Buffer.from('contents of foo/bar'))
+    expect(container.exists()).to.equal(true)
+
+    const members = await container.getMembers()
+    expect(members).to.deep.equal(['bar'])
+  })
+
+  describe('after adding some data', function () {
+    beforeEach(function () {
+      this.storage.getBlob(new Path('foo/bar')).setData(Buffer.from('I am foo/bar'))
+      this.storage.getBlob(new Path('foo/baz/1')).setData(Buffer.from('I am foo/baz/1'))
+      this.storage.getBlob(new Path('foo/baz/2')).setData(Buffer.from('I am foo/baz/2'))
+    })
+
+    it('correctly reports the container member listings', async function () {
+      const containerFoo: Container = this.storage.getContainer(new Path('foo/'))
+      const containerBaz: Container = this.storage.getContainer(new Path('foo/baz/'))
+      const membersFoo = await containerFoo.getMembers()
+      expect(membersFoo).to.deep.equal(['bar', 'baz/'])
+      const membersBaz = await containerBaz.getMembers()
+      expect(membersBaz).to.deep.equal(['1', '2'])
+    })
+
+    it('correctly deletes blobs', async function () {
+      const blobFooBar: Blob = this.storage.getBlob(new Path('foo/bar'))
+      const blobFooBaz1: Blob = this.storage.getBlob(new Path('foo/baz/1'))
+
+      // delete foo/bar
+      expect(blobFooBar.exists()).to.equal(true)
+      await blobFooBar.delete()
+      expect(blobFooBar.exists()).to.equal(false)
+
+      // delete foo/baz/1
+      expect(blobFooBaz1.exists()).to.equal(true)
+      await blobFooBaz1.delete()
+      expect(blobFooBaz1.exists()).to.equal(false)
+
+      const containerFoo: Container = this.storage.getContainer(new Path('foo/'))
+      const containerBaz: Container = this.storage.getContainer(new Path('foo/baz/'))
+      const membersFoo = await containerFoo.getMembers()
+      expect(membersFoo).to.deep.equal(['baz/'])
+      const membersBaz = await containerBaz.getMembers()
+      expect(membersBaz).to.deep.equal(['2'])
+    })
+
+    it('correctly deletes containers', async function () {
+      const containerFooBaz: Container = this.storage.getContainer(new Path('foo/baz/'))
+
+      // delete foo/baz/
+      expect(containerFooBaz.exists()).to.equal(true)
+      await containerFooBaz.delete()
+      expect(containerFooBaz.exists()).to.equal(false)
+
+      const containerFoo: Container = this.storage.getContainer(new Path('foo/'))
+      const membersFoo = await containerFoo.getMembers()
+      expect(membersFoo).to.deep.equal(['bar'])
+      const membersBaz = await containerFooBaz.getMembers()
+      expect(membersBaz).to.deep.equal([])
+    })
+  })
+})

--- a/test/unit/Path_test.ts
+++ b/test/unit/Path_test.ts
@@ -1,0 +1,30 @@
+import { expect } from 'chai'
+import 'mocha'
+import { Path } from '../../src/BlobTree'
+
+describe('Path', () => {
+  it('removes trailing slashes', function () {
+    const p = new Path('a/b/')
+    expect(p.asString()).to.equal('a/b')
+  })
+  it('removes leading slashes', function () {
+    const p = new Path('/a/b')
+    expect(p.asString()).to.equal('a/b')
+  })
+  it('removes empty segments', function () {
+    const p = new Path('a//b')
+    expect(p.asString()).to.equal('a/b')
+  })
+  it('allows for spaces', function () {
+    const p = new Path('a / b')
+    expect(p.asString()).to.equal('a / b')
+  })
+  it('allows for newlines', function () {
+    const p = new Path('a\n/\rb\t')
+    expect(p.asString()).to.equal('a\n/\rb\t')
+  })
+  it('allows for dots', function () {
+    const p = new Path('a/../b')
+    expect(p.asString()).to.equal('a/../b')
+  })
+})

--- a/test/unit/app.test.ts
+++ b/test/unit/app.test.ts
@@ -1,9 +1,0 @@
-import { expect } from 'chai';
-import 'mocha';
-
-describe('Trivial', () => {
-  it('is true', () => {
-    expect(true).to.equal(true);
-  });
-});
-


### PR DESCRIPTION
We need to add the following processors:

* [x] DetermineWebId (task.bearerToken -> webId)
* [x] DetermineAcl (task.path -> aclGraph)
* [ ] DetermineAllowedModesForAgent (webId + aclGraph -> listOfModes) (see [acl-check](https://github.com/solid/acl-check/blob/master/src/acl-check.js))
* [ ] DetermineAllowedModesForOrigin (task.origin + aclGraph -> listOfModes) (see [acl-check](https://github.com/solid/acl-check/blob/master/src/acl-check.js))

DetermineWebId is executed once for every http request.
DetermineAcl is executed once for every path used (could be one path per request, but could also be multiple ones for Globbing or possibly other server-side search features)
The intersection of AllowedModesForAgent and AllowedModesForOrigin is passed on to the ldp task executor which knows if it's doing a read, append, or write operation.