### PR TITLE
Add IResourceStore interface to various classes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,18 +14,18 @@
       }
     },
     "@babel/core": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.5.tgz",
-      "integrity": "sha512-i4qoSr2KTtce0DmkuuQBV4AuQgGPUcPXMr9L5MyYAtk06z068lQ10a4O009fe5OB/DfNV+h+qqT7ddNV8UnRjg==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.0.tgz",
+      "integrity": "sha512-FuRhDRtsd6IptKpHXAa+4WPZYY2ZzgowkbLBecEDDSje1X/apG7jQM33or3NdOmjXBKWGOg4JmSiRfUfuTtHXw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.5.5",
-        "@babel/helpers": "^7.5.5",
-        "@babel/parser": "^7.5.5",
-        "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.5.5",
-        "@babel/types": "^7.5.5",
+        "@babel/generator": "^7.6.0",
+        "@babel/helpers": "^7.6.0",
+        "@babel/parser": "^7.6.0",
+        "@babel/template": "^7.6.0",
+        "@babel/traverse": "^7.6.0",
+        "@babel/types": "^7.6.0",
         "convert-source-map": "^1.1.0",
         "debug": "^4.1.0",
         "json5": "^2.1.0",
@@ -44,12 +44,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.5.tgz",
-      "integrity": "sha512-ETI/4vyTSxTzGnU2c49XHv2zhExkv9JHLTwDAFz85kmcwuShvYG2H08FwgIguQf4JC75CBnXAUM5PqeF4fj0nQ==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.0.tgz",
+      "integrity": "sha512-Ms8Mo7YBdMMn1BYuNtKuP/z0TgEIhbcyB8HVR6PPNYp4P61lMsABiS4A3VG1qznjXVCf3r+fVHhm4efTYVsySA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.5.5",
+        "@babel/types": "^7.6.0",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
         "source-map": "^0.5.0",
@@ -100,14 +100,14 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.5.tgz",
-      "integrity": "sha512-nRq2BUhxZFnfEn/ciJuhklHvFOqjJUD5wpx+1bxUF2axL9C+v4DE/dmp5sT2dKnpOs4orZWzpAZqlCy8QqE/7g==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.6.0.tgz",
+      "integrity": "sha512-W9kao7OBleOjfXtFGgArGRX6eCP0UEcA2ZWEWNkJdRZnHhW4eEbeswbG3EwaRsnQUAEGWYgMq1HsIXuNNNy2eQ==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.4.4",
-        "@babel/traverse": "^7.5.5",
-        "@babel/types": "^7.5.5"
+        "@babel/template": "^7.6.0",
+        "@babel/traverse": "^7.6.0",
+        "@babel/types": "^7.6.0"
       }
     },
     "@babel/highlight": {
@@ -122,9 +122,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
-      "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
+      "integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==",
       "dev": true
     },
     "@babel/plugin-syntax-object-rest-spread": {
@@ -137,45 +137,45 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
-      "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.0.tgz",
+      "integrity": "sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==",
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
     },
     "@babel/template": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
-      "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
+      "integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.4.4",
-        "@babel/types": "^7.4.4"
+        "@babel/parser": "^7.6.0",
+        "@babel/types": "^7.6.0"
       }
     },
     "@babel/traverse": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.5.tgz",
-      "integrity": "sha512-MqB0782whsfffYfSjH4TM+LMjrJnhCNEDMDIjeTpl+ASaUvxcjoiVCo/sM1GhS1pHOXYfWVCYneLjMckuUxDaQ==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.0.tgz",
+      "integrity": "sha512-93t52SaOBgml/xY74lsmt7xOR4ufYvhb5c5qiM6lu4J/dWGMAfAh6eKw4PjLes6DI6nQgearoxnFJk60YchpvQ==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
-        "@babel/generator": "^7.5.5",
+        "@babel/generator": "^7.6.0",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-split-export-declaration": "^7.4.4",
-        "@babel/parser": "^7.5.5",
-        "@babel/types": "^7.5.5",
+        "@babel/parser": "^7.6.0",
+        "@babel/types": "^7.6.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.13"
       }
     },
     "@babel/types": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.5.tgz",
-      "integrity": "sha512-s63F9nJioLqOlW3UkyMd+BYhXt44YuaFm/VV0VwuteqjYwRrObkU7ra9pY4wAJR3oXi8hJrMcrcJdO/HH33vtw==",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
+      "integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
@@ -1581,9 +1581,9 @@
       }
     },
     "@types/node": {
-      "version": "12.7.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.4.tgz",
-      "integrity": "sha512-W0+n1Y+gK/8G2P/piTkBBN38Qc5Q1ZSO6B5H3QmPCUewaiXOo2GCAWZ4ElZCcNhjJuBSUSLGFUJnmlCn5+nxOQ=="
+      "version": "12.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
+      "integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w=="
     },
     "@types/node-fetch": {
       "version": "2.5.0",
@@ -1666,9 +1666,9 @@
       }
     },
     "@types/yargs-parser": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.0.0.tgz",
-      "integrity": "sha512-wBlsw+8n21e6eTd4yVv8YD/E3xq0O6nNnJIquutAsFGE7EyMKz7W6RNT6BRu1SmdgmlCZ9tb0X+j+D6HGr8pZw==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
+      "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
       "dev": true
     },
     "JSONStream": {
@@ -1702,9 +1702,9 @@
       "dev": true
     },
     "acorn-globals": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.3.tgz",
-      "integrity": "sha512-vkR40VwS2SYO98AIeFvzWWh+xyc2qi9s7OoXSFEGIP/rOJKzjnhykaZJNnHdoq4BL2gGxI5EZOU16z896EYnOQ==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
+      "integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
       "dev": true,
       "requires": {
         "acorn": "^6.0.1",
@@ -2910,9 +2910,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.1.tgz",
-      "integrity": "sha512-cp/Tb1oA/rh2X7vqeSOvM+TSo3UkJLX70eNihgVEvnzwAgikjkTFr/QVgRCaxjm0knCNQzNoxxxcw2zO2LJdZA==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.2.tgz",
+      "integrity": "sha512-DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.0",
@@ -3368,9 +3368,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.8.1.tgz",
-      "integrity": "sha512-micCIbldHioIegeKs41DoH0KS3AXfFzgS30qVkM6z/XOE/GJgvmsoc839NUqa1B9udYe9dQxgv7KFwng6+p/dw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.9.0.tgz",
+      "integrity": "sha512-CRcPzsSIbXyVDl0QI01muNDu69S8trU4jArW9LpOt2WtC6LyUJetcIrmfHsRBx7/Jb6GHJUiuqyYxPooFfNt6A==",
       "requires": {
         "debug": "^3.0.0"
       },
@@ -4076,9 +4076,9 @@
       "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
     },
     "graphql": {
-      "version": "14.5.4",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.5.4.tgz",
-      "integrity": "sha512-dPLvHoxy5m9FrkqWczPPRnH0X80CyvRE6e7Fa5AWEqEAzg9LpxHvKh24po/482E6VWHigOkAmb4xCp6P9yT9gw==",
+      "version": "14.5.6",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.5.6.tgz",
+      "integrity": "sha512-zJ6Oz8P1yptV4O4DYXdArSwvmirPetDOBnGFRBl0zQEC68vNW3Ny8qo8VzMgfr+iC8PKiRYJ+f2wub41oDCoQg==",
       "requires": {
         "iterall": "^1.2.2"
       }
@@ -4096,9 +4096,9 @@
       }
     },
     "graphql-to-sparql": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/graphql-to-sparql/-/graphql-to-sparql-2.0.0.tgz",
-      "integrity": "sha512-mU0D+kjr+udgk7Sxh1MfCOa6ATAKnZiyYAIGxbCxgQBaDjZTqyfGG5jfD8ji6I9tixxt7A6U2L/Zh+gfVWny4w==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/graphql-to-sparql/-/graphql-to-sparql-2.0.1.tgz",
+      "integrity": "sha512-fFSemLhCmYLVx+boOT0AKeOGwk6En4v8UYBTv8fL8ltRks2qhZjvAQDGXyWadspwSH1AV0COzJ0qDaU4LQqzzw==",
       "requires": {
         "@rdfjs/data-model": "^1.1.1",
         "@types/rdf-js": "^2.0.1",
@@ -5466,6 +5466,12 @@
       "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
       "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw="
     },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
+      "dev": true
+    },
     "lodash.omit": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
@@ -6388,9 +6394,9 @@
       }
     },
     "psl": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.3.1.tgz",
-      "integrity": "sha512-2KLd5fKOdAfShtY2d/8XDWVRnmp3zp40Qt6ge2zBPFARLXOGUf2fHD5eg+TV/5oxBtQKVhjUaKFsAaE4HnwfSA=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
+      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw=="
     },
     "pump": {
       "version": "3.0.0",
@@ -7559,7 +7565,7 @@
       }
     },
     "solid-server-ts": {
-      "version": "github:inrupt/solid-server-ts#da35effdc7e676a6d92d6bb65f7a3f325a4301f4",
+      "version": "github:inrupt/solid-server-ts#29177d38052782487d4e4359a3eeaef506b29055",
       "from": "github:inrupt/solid-server-ts#dev",
       "requires": {
         "express": "^4.16.3",
@@ -7614,9 +7620,9 @@
       }
     },
     "sparqlee": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/sparqlee/-/sparqlee-1.2.0.tgz",
-      "integrity": "sha512-IpYIg/mV1L3QWH0U96pJpnKg5nZ/w0dRlVI8xgFYp2Pb16TYxxTNmh3/QXrqS1VbotaM5irMKG9YDKJIWbeZdg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sparqlee/-/sparqlee-1.2.1.tgz",
+      "integrity": "sha512-53k71TZny074twc8RHoOon4dlFvMjjqo4oScPkyN6cqrj33qea9rFNW2hCV/xv9oZApKSBaffUu4DoRre6Ytrg==",
       "requires": {
         "@rdfjs/data-model": "^1.1.0",
         "@types/asynciterator": "^1.1.0",
@@ -7647,9 +7653,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.17",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.17.tgz",
-          "integrity": "sha512-p/sGgiPaathCfOtqu2fx5Mu1bcjuP8ALFg4xpGgNkcin7LwRyzUKniEHBKdcE1RPsenq5JVPIpMTJSygLboygQ=="
+          "version": "10.14.18",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.18.tgz",
+          "integrity": "sha512-ryO3Q3++yZC/+b8j8BdKd/dn9JlzlHBPdm80656xwYUdmPkpTGTjkAdt6BByiNupGPE8w0FhBgvYy/fX9hRNGQ=="
         }
       }
     },
@@ -7674,9 +7680,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.17",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.17.tgz",
-          "integrity": "sha512-p/sGgiPaathCfOtqu2fx5Mu1bcjuP8ALFg4xpGgNkcin7LwRyzUKniEHBKdcE1RPsenq5JVPIpMTJSygLboygQ=="
+          "version": "10.14.18",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.18.tgz",
+          "integrity": "sha512-ryO3Q3++yZC/+b8j8BdKd/dn9JlzlHBPdm80656xwYUdmPkpTGTjkAdt6BByiNupGPE8w0FhBgvYy/fX9hRNGQ=="
         }
       }
     },
@@ -7846,23 +7852,23 @@
       }
     },
     "string.prototype.trimleft": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.0.0.tgz",
-      "integrity": "sha1-aLaqjhYsaoDnbjqKDC50cYbicf8=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.0.2"
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
       }
     },
     "string.prototype.trimright": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.0.0.tgz",
-      "integrity": "sha1-q0pW2AKgH75yk+EehPJNyBZGYd0=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.0.2"
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
       }
     },
     "string_decoder": {
@@ -8053,15 +8059,16 @@
       "dev": true
     },
     "ts-jest": {
-      "version": "24.0.2",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-24.0.2.tgz",
-      "integrity": "sha512-h6ZCZiA1EQgjczxq+uGLXQlNgeg02WWJBbeT8j6nyIBRQdglqbvzDoHahTEIiS6Eor6x8mK6PfZ7brQ9Q6tzHw==",
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-24.1.0.tgz",
+      "integrity": "sha512-HEGfrIEAZKfu1pkaxB9au17b1d9b56YZSqz5eCVE8mX68+5reOvlM93xGOzzCREIov9mdH7JBG+s0UyNAqr0tQ==",
       "dev": true,
       "requires": {
         "bs-logger": "0.x",
         "buffer-from": "1.x",
         "fast-json-stable-stringify": "2.x",
         "json5": "2.x",
+        "lodash.memoize": "4.x",
         "make-error": "1.x",
         "mkdirp": "0.x",
         "resolve": "1.x",
@@ -8087,9 +8094,9 @@
       }
     },
     "ts-node": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.3.0.tgz",
-      "integrity": "sha512-dyNS/RqyVTDcmNM4NIBAeDMpsAdaQ+ojdf0GOLqE6nwJOgzEkdRNzJywhDfwnuvB10oa6NLVG1rUJQCpRN7qoQ==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.4.1.tgz",
+      "integrity": "sha512-5LpRN+mTiCs7lI5EtbXmF/HfMeCjzt7DH9CZwtkr6SywStrNQC723wG+aOWFiLNn7zT3kD/RnFqi3ZUfr4l5Qw==",
       "dev": true,
       "requires": {
         "arg": "^4.1.0",
@@ -8149,16 +8156,16 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.19.0.tgz",
-      "integrity": "sha512-1LwwtBxfRJZnUvoS9c0uj8XQtAnyhWr9KlNvDIdB+oXyT+VpsOAaEhEgKi1HrZ8rq0ki/AAnbGSv4KM6/AfVZw==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.20.0.tgz",
+      "integrity": "sha512-2vqIvkMHbnx8acMogAERQ/IuINOq6DFqgF8/VDvhEkBqQh/x6SP0Y+OHnKth9/ZcHQSroOZwUQSN18v8KKF0/g==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "builtin-modules": "^1.1.1",
         "chalk": "^2.3.0",
         "commander": "^2.12.1",
-        "diff": "^3.2.0",
+        "diff": "^4.0.1",
         "glob": "^7.1.1",
         "js-yaml": "^3.13.1",
         "minimatch": "^3.0.4",
@@ -8167,14 +8174,6 @@
         "semver": "^5.3.0",
         "tslib": "^1.8.0",
         "tsutils": "^2.29.0"
-      },
-      "dependencies": {
-        "diff": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-          "dev": true
-        }
       }
     },
     "tslint-config-standard": {
@@ -8299,9 +8298,9 @@
       }
     },
     "typescript": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.2.tgz",
-      "integrity": "sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
+      "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==",
       "dev": true
     },
     "uglify-js": {

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -5,6 +5,9 @@ import IResourceIdentifier from 'solid-server-ts/src/ldp/IResourceIdentifier'
 import ICredentials from 'solid-server-ts/src/auth/ICredentials'
 import PermissionSet from 'solid-server-ts/src/permissions/PermissionSet'
 import IAuthorizer from 'solid-server-ts/src/auth/IAuthorizer'
+import IRepresentationPreferences from 'solid-server-ts/src/ldp/IRepresentationPreferences'
+import Conditions from 'solid-server-ts/src/ldp/Conditions'
+import IPatch from 'solid-server-ts/src/ldp/IPatch'
 
 export { WacLdp, WacLdpOptions, BEARER_PARAM_NAME } from './lib/core/WacLdp'
 export { determineWebIdAndOrigin } from './lib/api/authentication/determineWebIdAndOrigin'
@@ -15,19 +18,19 @@ export { QuadAndBlobStore } from './lib/storage/QuadAndBlobStore'
 export { ACL } from './lib/rdf/rdf-constants'
 
 export class NssCompatResourceStore implements IResourceStore {
-  async getRepresentation () {
+  async getRepresentation (resourceIdentifier: IResourceIdentifier, representationPreferences: IRepresentationPreferences, conditions: Conditions) {
     return {} as IRepresentation
   }
-  async setRepresentation () {
-    // ...
-  }
-  async addResource () {
+  async addResource (container: IResourceIdentifier, representation: IRepresentation, conditions: Conditions) {
     return {} as IResourceIdentifier
   }
-  async modifyResource () {
+  async setRepresentation (resourceIdentifier: IResourceIdentifier, representation: IRepresentation, conditions: Conditions) {
     // ...
   }
-  async deleteResource () {
+  async deleteResource (resourceIdentifier: IResourceIdentifier, conditions: Conditions) {
+    // ...
+  }
+  async modifyResource (resourceIdentifier: IResourceIdentifier, patch: IPatch, conditions: Conditions) {
     // ...
   }
 }

--- a/src/lib/authorization/AclManager.ts
+++ b/src/lib/authorization/AclManager.ts
@@ -109,7 +109,7 @@ export class AclManager {
       `    acl:Read, acl:Write, acl:Control.`
     ].join('\n'))
     const buffer = Buffer.from(JSON.stringify(obj))
-    return this.storeManager.setRepresentation(rootAclUrl, bufferToStream(buffer))
+    return this.storeManager.setResourceData(rootAclUrl, bufferToStream(buffer))
   }
   setPublicAcl (containerUrl: URL, owner: URL, modeName: string): Promise<void> {
     let containerUrlStr = containerUrl.toString()
@@ -137,6 +137,6 @@ export class AclManager {
       `    acl:${modeName}.`
     ].join('\n'))
     const buffer = Buffer.from(JSON.stringify(obj))
-    return this.storeManager.setRepresentation(containerAclUrl, bufferToStream(buffer))
+    return this.storeManager.setResourceData(containerAclUrl, bufferToStream(buffer))
   }
 }

--- a/src/lib/core/WacLdp.ts
+++ b/src/lib/core/WacLdp.ts
@@ -91,7 +91,7 @@ export class WacLdp extends EventEmitter implements IHttpHandler {
     return this.aclManager.setPublicAcl(inboxUrl, owner, modeName)
   }
   createLocalDocument (url: URL, contentType: string, body: string) {
-    return this.storeManager.setRepresentation(url, objectToStream(makeResourceData(contentType, body)))
+    return this.storeManager.setResourceData(url, objectToStream(makeResourceData(contentType, body)))
   }
   containerExists (url: URL) {
     return this.storeManager.getLocalContainer(url).exists()

--- a/src/lib/operationHandlers/getResourceDataAndCheckETag.ts
+++ b/src/lib/operationHandlers/getResourceDataAndCheckETag.ts
@@ -4,7 +4,7 @@ import { StoreManager } from '../rdf/StoreManager'
 import { ResourceData } from '../rdf/ResourceDataUtils'
 
 export async function getResourceDataAndCheckETag (wacLdpTask: WacLdpTask, storeManager: StoreManager): Promise<ResourceData | undefined> {
-  const resourceData = await storeManager.getRepresentation(wacLdpTask.fullUrl())
+  const resourceData = await storeManager.getResourceData(wacLdpTask.fullUrl())
   // See https://github.com/inrupt/wac-ldp/issues/114
   const resultTypeToUse = (wacLdpTask.isReadOperation() ? ResultType.NotModified : ResultType.PreconditionFailed)
   if (resourceData) { // resource exists

--- a/src/lib/operationHandlers/writeBlobHandler.ts
+++ b/src/lib/operationHandlers/writeBlobHandler.ts
@@ -29,7 +29,7 @@ export const writeBlobHandler = {
     const contentType: string | undefined = task.contentType()
     debug('contentType', contentType)
     const resourceData = makeResourceData(contentType ? contentType : '', await task.requestBody())
-    await storeManager.setRepresentation(task.fullUrl(), objectToStream(resourceData))
+    await storeManager.setResourceData(task.fullUrl(), objectToStream(resourceData))
     debug('write blob handler changed a resource', task.fullUrl())
     return {
       resultType,

--- a/src/lib/rdf/applyPatch.ts
+++ b/src/lib/rdf/applyPatch.ts
@@ -1,0 +1,7 @@
+import IPatch from 'solid-server-ts/src/ldp/IPatch'
+import { ResourceData } from '../rdf/ResourceDataUtils'
+
+export default function applyPatch (patch: IPatch, resourceData: ResourceData) {
+  // TODO: implement
+  return resourceData
+}

--- a/src/lib/storage/BlobTree.ts
+++ b/src/lib/storage/BlobTree.ts
@@ -2,6 +2,7 @@ import * as events from 'events'
 import Debug from 'debug'
 import { Container } from './Container'
 import { Blob } from './Blob'
+import IResourceStore from 'solid-server-ts/src/ldp/IResourceStore'
 
 const debug = Debug('BlobTree')
 
@@ -117,7 +118,7 @@ export class Path {
 // getData/setData when doesn't exist
 // containers always exist, unless there is a blob at their filename
 // creating a path ignores the trailing slash
-export interface BlobTree extends events.EventEmitter {
+export interface BlobTree extends events.EventEmitter, IResourceStore {
   getContainer (path: Path): Container
   getBlob (path: Path): Blob
 }

--- a/src/lib/storage/BlobTreeInMem.ts
+++ b/src/lib/storage/BlobTreeInMem.ts
@@ -136,7 +136,7 @@ export class BlobTreeInMem extends events.EventEmitter {
     const blob = this.getBlob(urlToPath(childUrl))
     await blob.setData(await objectToStream({
       contentType: representation.metadata.contentType,
-      body: streamToBuffer(representation.data),
+      body: await streamToBuffer(representation.data),
       etag: 'hm'
     }))
     return {
@@ -148,7 +148,7 @@ export class BlobTreeInMem extends events.EventEmitter {
   }
   async setRepresentation (resourceIdentifier: IResourceIdentifier, representation: IRepresentation, conditions: Conditions) {
     const blob = this.getBlob(urlToPath(new URL(resourceIdentifier.path, resourceIdentifier.domain)))
-    const resourceData = makeResourceData(representation.metadata.contentType || 'application/octet-stream', streamToBuffer(representation.data).toString())
+    const resourceData = makeResourceData(representation.metadata.contentType || 'application/octet-stream', (await streamToBuffer(representation.data)).toString())
     console.log('set', resourceData)
     return blob.setData(await objectToStream(resourceData))
   }

--- a/src/lib/storage/BlobTreeInMem.ts
+++ b/src/lib/storage/BlobTreeInMem.ts
@@ -3,8 +3,17 @@ import Debug from 'debug'
 import { Node } from './Node'
 import { Container, Member } from './Container'
 import { Blob } from './Blob'
-import { BlobTree, Path } from './BlobTree'
-import { bufferToStream, streamToBuffer } from '../rdf/ResourceDataUtils'
+import { BlobTree, Path, urlToPath } from './BlobTree'
+import { bufferToStream, streamToBuffer, ResourceData, streamToObject, objectToStream } from '../rdf/ResourceDataUtils'
+import IRepresentation from 'solid-server-ts/src/ldp/IRepresentation'
+import IResourceIdentifier from 'solid-server-ts/src/ldp/IResourceIdentifier'
+import IRepresentationPreferences from 'solid-server-ts/src/ldp/IRepresentationPreferences'
+import Conditions from 'solid-server-ts/src/ldp/Conditions'
+import IPatch from 'solid-server-ts/src/ldp/IPatch'
+import { resourceDataToRdf } from '../rdf/mergeRdfSources'
+import applyPatch from '../rdf/applyPatch'
+import IRepresentationMetadata from 'solid-server-ts/src/ldp/IRepresentationMetadata'
+import uuid from 'uuid'
 
 const debug = Debug('AtomicTreeInMem')
 
@@ -103,5 +112,60 @@ export class BlobTreeInMem extends events.EventEmitter {
   }
   getBlob (path: Path) {
     return new BlobInMem(path, this)
+  }
+
+  async getRepresentation (resourceIdentifier: IResourceIdentifier, representationPreferences: IRepresentationPreferences, conditions: Conditions) {
+    const blob = this.getBlob(urlToPath(new URL(resourceIdentifier.path, resourceIdentifier.domain)))
+    const resourceData = await streamToObject(await blob.getData())
+    const metadata: IRepresentationMetadata = {
+      raw: [],
+      contentType: resourceData.contentType,
+      profiles: []
+    } as IRepresentationMetadata
+    return {
+      identifier: resourceIdentifier,
+      metadata,
+      data: bufferToStream(Buffer.from(resourceData.body)),
+      dataType: 'default'
+    } as IRepresentation
+  }
+  async addResource (container: IResourceIdentifier, representation: IRepresentation, conditions: Conditions) {
+    const childPath = container.path + uuid()
+    const childUrl = new URL(childPath, container.domain)
+    const blob = this.getBlob(urlToPath(childUrl))
+    await blob.setData(await objectToStream({
+      contentType: representation.metadata.contentType,
+      body: streamToBuffer(representation.data),
+      etag: 'hm'
+    }))
+    return {
+      domain: container.domain,
+      isAcl: false,
+      path: childPath
+    } as IResourceIdentifier
+
+  }
+  async setRepresentation (resourceIdentifier: IResourceIdentifier, representation: IRepresentation, conditions: Conditions) {
+    const blob = this.getBlob(urlToPath(new URL(resourceIdentifier.path, resourceIdentifier.domain)))
+    return blob.setData(await objectToStream({
+      contentType: representation.metadata.contentType,
+      body: streamToBuffer(representation.data),
+      etag: 'hm'
+    }))
+  }
+  async deleteResource (resourceIdentifier: IResourceIdentifier, conditions: Conditions) {
+    if (resourceIdentifier.path.substr(-1) === '/') {
+      const container = this.getContainer(urlToPath(new URL(resourceIdentifier.path, resourceIdentifier.domain)))
+      return container.delete()
+    } else {
+      const blob = this.getBlob(urlToPath(new URL(resourceIdentifier.path, resourceIdentifier.domain)))
+      return blob.delete()
+    }
+  }
+  async modifyResource (resourceIdentifier: IResourceIdentifier, patch: IPatch, conditions: Conditions) {
+    const blob = this.getBlob(urlToPath(new URL(resourceIdentifier.path, resourceIdentifier.domain)))
+    const resourceData = await streamToObject(await blob.getData())
+    const newResourceData = applyPatch(patch, resourceData)
+    return blob.setData(await objectToStream(newResourceData))
   }
 }

--- a/src/lib/storage/BlobTreeInMem.ts
+++ b/src/lib/storage/BlobTreeInMem.ts
@@ -117,7 +117,7 @@ export class BlobTreeInMem extends events.EventEmitter {
   async getRepresentation (resourceIdentifier: IResourceIdentifier, representationPreferences: IRepresentationPreferences, conditions: Conditions) {
     const blob = this.getBlob(urlToPath(new URL(resourceIdentifier.path, resourceIdentifier.domain)))
     const resourceData = await streamToObject(await blob.getData())
-    console.log('get', resourceData)
+    // console.klog('get', resourceData)
     const metadata: IRepresentationMetadata = {
       raw: [],
       contentType: resourceData.contentType,
@@ -149,7 +149,7 @@ export class BlobTreeInMem extends events.EventEmitter {
   async setRepresentation (resourceIdentifier: IResourceIdentifier, representation: IRepresentation, conditions: Conditions) {
     const blob = this.getBlob(urlToPath(new URL(resourceIdentifier.path, resourceIdentifier.domain)))
     const resourceData = makeResourceData(representation.metadata.contentType || 'application/octet-stream', (await streamToBuffer(representation.data)).toString())
-    console.log('set', resourceData)
+    // console.log('set', resourceData)
     return blob.setData(await objectToStream(resourceData))
   }
   async deleteResource (resourceIdentifier: IResourceIdentifier, conditions: Conditions) {

--- a/src/lib/storage/QuadAndBlobStore.ts
+++ b/src/lib/storage/QuadAndBlobStore.ts
@@ -4,11 +4,19 @@ import { Member } from './Container'
 import { membersListAsQuadStream } from './membersListAsResourceData'
 import { quadStreamFromBlob } from '../rdf/StoreManager'
 import { rdfToResourceData } from '../rdf/rdfToResourceData'
-import { RdfType, objectToStream } from '../rdf/ResourceDataUtils'
+import { RdfType, objectToStream, streamToBuffer, makeResourceData, streamToObject } from '../rdf/ResourceDataUtils'
+import IResourceIdentifier from 'solid-server-ts/src/ldp/IResourceIdentifier'
+import IRepresentationPreferences from 'solid-server-ts/src/ldp/IRepresentationPreferences'
+import Conditions from 'solid-server-ts/src/ldp/Conditions'
+import IRepresentation from 'solid-server-ts/src/ldp/IRepresentation'
+import uuid from 'uuid'
+import IPatch from 'solid-server-ts/src/ldp/IPatch'
+import applyPatch from '../rdf/applyPatch'
+import IResourceStore from 'solid-server-ts/src/ldp/IResourceStore'
 
 const debug = Debug('quad-and-blob-store')
 
-export class QuadAndBlobStore {
+export class QuadAndBlobStore implements IResourceStore {
   storage: BlobTree
   constructor (storage: BlobTree) {
     this.storage = storage
@@ -51,5 +59,21 @@ export class QuadAndBlobStore {
       const resourceData = rdfToResourceData(quadStream, RdfType.Turtle)
       return blob.setData(objectToStream(resourceData))
     }
+  }
+
+  getRepresentation (resourceIdentifier: IResourceIdentifier, representationPreferences: IRepresentationPreferences, conditions: Conditions) {
+    return this.storage.getRepresentation(resourceIdentifier, representationPreferences, conditions)
+  }
+  addResource (container: IResourceIdentifier, representation: IRepresentation, conditions: Conditions) {
+    return this.storage.addResource(container, representation, conditions)
+  }
+  setRepresentation (resourceIdentifier: IResourceIdentifier, representation: IRepresentation, conditions: Conditions) {
+    return this.storage.setRepresentation(resourceIdentifier, representation, conditions)
+  }
+  deleteResource (resourceIdentifier: IResourceIdentifier, conditions: Conditions) {
+    return this.storage.deleteResource(resourceIdentifier, conditions)
+  }
+  modifyResource (resourceIdentifier: IResourceIdentifier, patch: IPatch, conditions: Conditions) {
+    return this.storage.modifyResource(resourceIdentifier, patch, conditions)
   }
 }

--- a/test/unit/rdf/StoreManager-fetchGraph.test.ts
+++ b/test/unit/rdf/StoreManager-fetchGraph.test.ts
@@ -15,7 +15,7 @@ test('can fetch a local graph', async () => {
   const resourceData = makeResourceData('text/turtle', body.toString())
   await blob.setData(await objectToStream(resourceData))
   const storeManager = new StoreManager('example.com', storage)
-  const representation = await storeManager.getRepresentation(new URL('https://example.com/profile/card'))
+  const representation = await storeManager.getResourceData(new URL('https://example.com/profile/card'))
   expect(representation).toEqual({
     body: `\n\
 @prefix : <https://michielbdejong.com/profile/card#>.\n\
@@ -36,7 +36,7 @@ test('can fetch a local graph', async () => {
 test('can fetch a remote graph', async () => {
   const storage = new QuadAndBlobStore(new BlobTreeInMem())
   const storeManager = new StoreManager('example.com', storage)
-  const representation = await storeManager.getRepresentation(new URL('https://michielbdejong.com/profile/card'))
+  const representation = await storeManager.getResourceData(new URL('https://michielbdejong.com/profile/card'))
   expect(representation).toEqual({
     body: `\n\
 @prefix : <https://michielbdejong.com/profile/card#>.\n\

--- a/test/unit/storage/ResourceStores.test.ts
+++ b/test/unit/storage/ResourceStores.test.ts
@@ -6,11 +6,16 @@ import { bufferToStream, streamToBuffer } from '../../../src/lib/rdf/ResourceDat
 import IResourceIdentifier from 'solid-server-ts/src/ldp/IResourceIdentifier'
 import Conditions from 'solid-server-ts/src/ldp/Conditions'
 import IRepresentationPreferences from 'solid-server-ts/src/ldp/IRepresentationPreferences'
+import rimraf = require('rimraf')
 
 const stores = {
   'in-mem': new BlobTreeInMem(),
-  // 'nss-compat': new BlobTreeNssCompat('./tmp-data/')
+  'nss-compat': new BlobTreeNssCompat('./tmp-data/')
 }
+
+afterAll((done) => {
+  rimraf('./tmp-data', done)
+})
 
 for (let [storeName, store] of Object.entries(stores)) {
   describe(storeName, () => {

--- a/test/unit/storage/ResourceStores.test.ts
+++ b/test/unit/storage/ResourceStores.test.ts
@@ -20,9 +20,10 @@ for (let [storeName, store] of Object.entries(stores)) {
         contentType: 'text/plain',
         profiles: []
       } as IRepresentationMetadata
+      const original = Buffer.from('hello body')
       const representation = {
         metadata,
-        data: await bufferToStream(Buffer.from('hello body')),
+        data: await bufferToStream(original),
         dataType: 'default'
       } as IRepresentation
       const conditions = {
@@ -34,8 +35,9 @@ for (let [storeName, store] of Object.entries(stores)) {
         path: 'yes/it.does'
       } as IResourceIdentifier
       await store.setRepresentation(resourceIdentifier, representation, conditions)
-      const readBack = await store.getRepresentation(resourceIdentifier, {} as IRepresentationPreferences, {} as Conditions)
-      expect(await streamToBuffer(readBack)).toEqual(await streamToBuffer(representation))
+      const readBackRepresentation = await store.getRepresentation(resourceIdentifier, {} as IRepresentationPreferences, {} as Conditions)
+      const readBack = await streamToBuffer(readBackRepresentation.data)
+      expect(readBack).toEqual(original)
     })
   })
 }

--- a/test/unit/storage/ResourceStores.test.ts
+++ b/test/unit/storage/ResourceStores.test.ts
@@ -1,0 +1,41 @@
+import { BlobTreeInMem } from '../../../src/lib/storage/BlobTreeInMem'
+import { BlobTreeNssCompat } from '../../../src/lib/storage/BlobTreeNssCompat'
+import IRepresentation from 'solid-server-ts/src/ldp/IRepresentation'
+import IRepresentationMetadata from 'solid-server-ts/src/ldp/IRepresentationMetadata'
+import { bufferToStream, streamToBuffer } from '../../../src/lib/rdf/ResourceDataUtils'
+import IResourceIdentifier from 'solid-server-ts/src/ldp/IResourceIdentifier'
+import Conditions from 'solid-server-ts/src/ldp/Conditions'
+import IRepresentationPreferences from 'solid-server-ts/src/ldp/IRepresentationPreferences'
+
+const stores = {
+  'in-mem': new BlobTreeInMem(),
+  // 'nss-compat': new BlobTreeNssCompat('./tmp-data/')
+}
+
+for (let [storeName, store] of Object.entries(stores)) {
+  describe(storeName, () => {
+    test('setRepresentation / getRepresentation', async () => {
+      const metadata = {
+        raw: [],
+        contentType: 'text/plain',
+        profiles: []
+      } as IRepresentationMetadata
+      const representation = {
+        metadata,
+        data: await bufferToStream(Buffer.from('hello body')),
+        dataType: 'default'
+      } as IRepresentation
+      const conditions = {
+
+      } as Conditions
+      const resourceIdentifier = {
+        domain: 'https://rdf.rocks',
+        isAcl: false,
+        path: 'yes/it.does'
+      } as IResourceIdentifier
+      await store.setRepresentation(resourceIdentifier, representation, conditions)
+      const readBack = await store.getRepresentation(resourceIdentifier, {} as IRepresentationPreferences, {} as Conditions)
+      expect(await streamToBuffer(readBack)).toEqual(await streamToBuffer(representation))
+    })
+  })
+}


### PR DESCRIPTION
In preparation for Operation Treasure Trove, moulding this code so that it starts to look as much as possible like Ruben's architecture. Starting with adding functionality to the two BlobTree implementations, so that they implement the full IResourceStore interface.

The meat is in https://github.com/inrupt/wac-ldp/compare/resourcestore?expand=1#diff-d386beb8a1b5082184266f210ab81642R117-R170 and so far it looks like it can be quite a thin wrapper, although we still need to add applyPatch and handling of Conditions.